### PR TITLE
feat: 서버 종료시 제대로 thread가 정리되지 않던 문제 해결 (ref #17)

### DIFF
--- a/src/server/reactor/Worker.h
+++ b/src/server/reactor/Worker.h
@@ -3,21 +3,23 @@
 
 #include <functional>
 #include <thread>
+#include <atomic>
 #include "../threadpool/WorkerQueue.h"
 
 class Worker {
 public:
     
-    Worker(std::shared_ptr<WorkerQueue<std::function<void()>>> taskQueue);
+    Worker(int workerId, std::shared_ptr<WorkerQueue<std::function<void()>>> taskQueue);
     ~Worker();
 
     void start();
     void stop();
 
 private:
+    int workerId;
     std::shared_ptr<WorkerQueue<std::function<void()>>> taskQueue;
     std::thread thread;
-    bool running;
+    std::atomic<bool> running;
 };
 
 #endif

--- a/src/server/threadpool/ThreadPool.cpp
+++ b/src/server/threadpool/ThreadPool.cpp
@@ -6,15 +6,18 @@
 
 using namespace std;
 
-ThreadPool::ThreadPool(int numThreads) : taskQueue(make_shared<WorkerQueue<std::function<void()>>>()) {
+ThreadPool::ThreadPool(int numThreads) 
+    : running(true), taskQueue(make_shared<WorkerQueue<std::function<void()>>>()) {
     for (int i = 0; i < numThreads; ++i) {
-        workers.emplace_back(make_unique<Worker>(taskQueue));
+        workers.emplace_back(make_unique<Worker>(i, taskQueue));
         workers.back()->start();
     }
 }
 
 ThreadPool::~ThreadPool(){
-    stop();
+    if(running){
+        stop();
+    }
 }
 
 // 작업 Queue에 작업 할당
@@ -27,8 +30,12 @@ void ThreadPool::enqueueTask(const function<void()>& task) {
 
 // ThreadPool내 Worker 정리
 void ThreadPool::stop() {
+    for (size_t i = 0; i < workers.size(); ++i) {
+        taskQueue->push(nullptr);
+    }
     for (auto& worker : workers) {
         worker->stop();
     }
+    running = false;
     Logger::debug("Thread pool shutdown.");
 }

--- a/src/server/threadpool/ThreadPool.h
+++ b/src/server/threadpool/ThreadPool.h
@@ -17,6 +17,7 @@ public:
     void stop();
 
 private:
+    bool running;
     std::shared_ptr<WorkerQueue<std::function<void()>>> taskQueue;
     std::vector<std::unique_ptr<Worker>> workers;
 };


### PR DESCRIPTION
- 해당 문제는 worker에서 queue의 작업이 있을때까지 bloking되는 것이 문제 였다.
- 원래는 nullptr이 들어가면서 종료되어야하지만 두가지 문제점을 고려하지 못해서 삽질함

1) worker queue에 넣은 nullptr을 다른 worker가 먼저 소비하고 종료됨. 2) 먼저 종료된 worker는 stop이 불리지 않았으므로 대기 상태.
3) 마치 데드락과 같은 상태가 되어버림...

문제 해결)
queue안에 종료신호(nullptr)을 thread 개수만큼 이리 삽입후
worker(thread)에 종료신호를 보냄.

다른 대안이 있는가?)
worker의 running 변수를 threadpool에서 관리하고 동시에 종료시키면 간단함! 단점은 worker를 개별적으로 종료시킬 수 없음

해당 방법은 추후 시도해볼 것

## 📌 개요
<!-- PR의 목적과 관련된 이슈 번호를 명확히 작성해주세요. -->
- 관련 이슈: #이슈번호

---

## ✨ 변경 사항
<!-- 이번 PR에서 변경된 사항을 간략히 설명해주세요. -->
- [변경 사항 1]
- [변경 사항 2]
- [변경 사항 3]

---

## 🛠 주요 변경점
<!-- 코드 변경에서 특히 주목해야 할 주요 부분을 설명해주세요. -->
- [주요 변경 내용 1]
- [주요 변경 내용 2]

---

## 📷 스크린샷 (선택)
<!-- UI 관련 변경 사항이 있다면 스크린샷을 첨부해주세요. -->
| 변경 전 | 변경 후 |
|---------|---------|
| (이미지) | (이미지) |

---

## ✅ 체크리스트
<!-- PR을 제출하기 전에 아래 항목을 확인해주세요. -->
- [ ] 내 코드가 프로젝트의 스타일 가이드에 맞게 작성되었나요?
- [ ] 필요한 문서를 작성하거나 수정했나요?
- [ ] 기존 기능에 영향을 주지 않는지 확인했나요?
- [ ] 관련된 이슈를 닫거나 링크했나요?

---

## 💬 기타 사항 (선택)
<!-- 리뷰어가 참고해야 할 추가적인 사항이 있다면 작성해주세요. -->
